### PR TITLE
feat(python): implementar cálculo de insumos (tomate e soja)

### DIFF
--- a/python/app/menu.py
+++ b/python/app/menu.py
@@ -8,6 +8,7 @@ def run_menu():
         print("3) Atualizar por índice")
         print("4) Deletar por índice")
         print("5) Gerar relatório CSV")
+        print("6) Calcular insumos")
         print("0) Sair")
         opcao = input("Escolha uma opção: ").strip()
 
@@ -17,6 +18,7 @@ def run_menu():
             case "3": atualizar()
             case "4": deletar()
             case "5": op.exportar_csv()  # Nova opção para exportar CSV
+            case "6": insumos()
             case "0":
                 print("Saindo... até logo!")
                 break
@@ -63,7 +65,6 @@ def atualizar():
     except IndexError:
         print("⚠️ Índice inválido.")
 
-
 def deletar():
     print("\n=== Deletar ===")
     cultura = input("tomate/soja: ").strip().lower()
@@ -76,3 +77,10 @@ def deletar():
         print("✅ Deletado com sucesso.")
     except IndexError:
         print("⚠️ Índice inválido.")
+
+def insumos():
+    print("\n=== Cálculo de Insumos ===")
+    cultura = input("Cultura (tomate/soja): ").strip().lower()
+    produto = input("Produto: ").strip()
+    dose = float(input("Dose (L/m²): ").replace(",", "."))
+    op.calcular_insumos(cultura, produto, dose)

--- a/python/app/operations.py
+++ b/python/app/operations.py
@@ -25,6 +25,7 @@ def deletar(cultura: str, idx: int):
     delete(cultura, idx)
     
 def exportar_csv(nome_base: str = "plantio") -> None:
+
     """Exporta os dados das culturas para um arquivo CSV com timestamp no nome."""
     timestamp = datetime.datetime.now().strftime("%d%m%Y-%H%M")
     filepath = f"data/{nome_base}-{timestamp}.csv"
@@ -41,3 +42,27 @@ def exportar_csv(nome_base: str = "plantio") -> None:
                 writer.writerow([cultura, area])
 
     print(f"✅ Dados exportados com sucesso para {filepath}")
+
+def calcular_insumos(cultura: str, produto: str, dose_por_m2: float) -> float:
+    """
+    Calcula a quantidade total de insumo necessária para uma cultura.
+    - cultura: 'tomate' ou 'soja'
+    - produto: nome do insumo (ex: 'fertilizante X')
+    - dose_por_m2: litros ou mL por metro quadrado
+    """
+   
+    areas = dados.get(cultura, [])
+    if not areas:
+        print(f"⚠️ Nenhuma área cadastrada para {cultura}.")
+        return 0.0
+
+    total_area = sum(areas)
+    total_insumo = total_area * dose_por_m2
+
+    print(f"➡️ Cultura: {cultura}")
+    print(f"➡️ Produto: {produto}")
+    print(f"➡️ Área total: {total_area:.2f} m²")
+    print(f"➡️ Dose aplicada: {dose_por_m2} L/m²")
+    print(f"✅ Quantidade necessária: {total_insumo:.2f} L de {produto}")
+
+    return total_insumo


### PR DESCRIPTION
🔨 Alterações principais

Implementada função calcular_insumos para tomate e soja.

Menu atualizado com a opção 6) Calcular insumos.

Entrada de dose em L/m² com suporte a vírgula ou ponto.

Cálculo automático da quantidade necessária de insumo com base na área cadastrada.

Mensagem de aviso caso não haja áreas registradas para a cultura escolhida.

✅ Exemplo de uso

Tomate: área total 200 m²

Dose: 0,5 L/m²

Resultado: 100 L necessários